### PR TITLE
Update lodash@3.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "entities": "~1.1.1",
     "htmlparser2": "~3.8.1",
     "dom-serializer": "~0.0.0",
-    "lodash": "~2.4.1"
+    "lodash": "~3.1.0"
   },
   "devDependencies": {
     "benchmark": "~1.0.0",


### PR DESCRIPTION
This PR updates lodash to the version  `3.1.0`. The version `2.4.1` was crashing in web worker.